### PR TITLE
Feature/exit codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+yarn-error.log

--- a/bin/meta-exec
+++ b/bin/meta-exec
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const metaLoop = require('meta-loop');
+const metaLoop = require('@essential-projects/meta-loop');
 
 if ( ! process.argv[2] || process.argv[2] === '--help')
   return console.log(`\n  usage:\n\n    meta exec <command>\n`);

--- a/bin/meta-exec
+++ b/bin/meta-exec
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const metaLoop = require('@essential-projects/meta-loop');
+const metaLoop = require('meta-loop');
 
 if ( ! process.argv[2] || process.argv[2] === '--help')
   return console.log(`\n  usage:\n\n    meta exec <command>\n`);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const chalk = require('chalk');
-const debug = require('debug')('meta-exec');
+const debug = require('debug')('@essential-projects/meta-exec');
 const execSync = require('child_process').execSync;
 const path = require('path');
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const chalk = require('chalk');
-const debug = require('debug')('@essential-projects/meta-exec');
+const debug = require('debug')('meta-exec');
 const execSync = require('child_process').execSync;
 const path = require('path');
 
@@ -19,7 +19,7 @@ module.exports = function (options, cb) {
 
     if ( ! options.suppressLogging) console.log(`\n${chalk.cyan(path.basename(options.displayDir))}:`)
 
-    code = execSync(options.cmd, { cwd: options.dir, env: process.env, stdio: 'inherit' });
+    code = execSync(options.cmd, { cwd: options.dir, env: process.env, stdio:[0,1,2] });
 
   } catch (err) {
     
@@ -28,7 +28,11 @@ module.exports = function (options, cb) {
     let errorMessage = `${chalk.red(path.basename(options.displayDir))} exited with error: ${err.toString()}`;
     
     if ( ! options.suppressLogging) console.error(errorMessage);
-    
+
+    if (options.exitOnError) {
+      process.exit(1);
+    }
+
     if (cb) return cb(null, { error: errorMessage });
 
     return;
@@ -40,7 +44,11 @@ module.exports = function (options, cb) {
     let errorMessage = `${chalk.red(path.basename(options.displayDir))} exited with code: ${code}`;
     
     if ( ! options.suppressLogging) console.error(errorMessage);
-    
+
+    if (options.exitOnError) {
+      process.exit(1);
+    }
+
     if (cb) return cb(null, { err: errorMessage });
 
     return;

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,5 +1,5 @@
 const chalk = require('chalk');
-const debug = require('debug')('meta-exec');
+const debug = require('debug')('@essential-projects/meta-exec');
 const execSync = require('child_process').execSync;
 const path = require('path');
 

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -3,7 +3,7 @@ const debug = require('debug')('meta-exec');
 const execSync = require('child_process').execSync;
 const path = require('path');
 
-module.exports = function (options, cb) {
+module.exports = function (options, cb, errorCb) {
 
   if (options.suppressLogging === undefined) options.suppressLogging = false;
 
@@ -23,15 +23,12 @@ module.exports = function (options, cb) {
 
   } catch (err) {
 
-    // a cmd error isnt a loop error,
-    // we just want to output the cmd's output
+    if (errorCb) errorCb(err);
+    
+    // if there is no error callback, we're just going to forward the output
     let errorMessage = `${chalk.red(path.basename(options.displayDir))} exited with error: ${err.toString()}`;
     
     if ( ! options.suppressLogging) console.error(errorMessage);
-
-    if (options.exitOnError) {
-      process.exit(1);
-    }
 
     if (cb) return cb(null, { error: errorMessage });
 
@@ -40,19 +37,16 @@ module.exports = function (options, cb) {
   }
 
   if (code) {
-    
+
     let errorMessage = `${chalk.red(path.basename(options.displayDir))} exited with code: ${code}`;
+
+    if (errorCb) errorCb(new Error(errorMessage));
     
     if ( ! options.suppressLogging) console.error(errorMessage);
-
-    if (options.exitOnError) {
-      process.exit(1);
-    }
 
     if (cb) return cb(null, { err: errorMessage });
 
     return;
-
   } 
 
   let success = chalk.green(`${path.basename(options.displayDir)} ✓`);

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,5 +1,5 @@
 const chalk = require('chalk');
-const debug = require('debug')('@essential-projects/meta-exec');
+const debug = require('debug')('meta-exec');
 const execSync = require('child_process').execSync;
 const path = require('path');
 
@@ -19,16 +19,20 @@ module.exports = function (options, cb) {
 
     if ( ! options.suppressLogging) console.log(`\n${chalk.cyan(path.basename(options.displayDir))}:`)
 
-    code = execSync(options.cmd, { cwd: options.dir, env: process.env, stdio: 'inherit' });
+    code = execSync(options.cmd, { cwd: options.dir, env: process.env, stdio: [0,1,2] });
 
   } catch (err) {
-    
+
     // a cmd error isnt a loop error,
     // we just want to output the cmd's output
     let errorMessage = `${chalk.red(path.basename(options.displayDir))} exited with error: ${err.toString()}`;
     
     if ( ! options.suppressLogging) console.error(errorMessage);
-    
+
+    if (options.exitOnError) {
+      process.exit(1);
+    }
+
     if (cb) return cb(null, { error: errorMessage });
 
     return;
@@ -40,7 +44,11 @@ module.exports = function (options, cb) {
     let errorMessage = `${chalk.red(path.basename(options.displayDir))} exited with code: ${code}`;
     
     if ( ! options.suppressLogging) console.error(errorMessage);
-    
+
+    if (options.exitOnError) {
+      process.exit(1);
+    }
+
     if (cb) return cb(null, { err: errorMessage });
 
     return;
@@ -50,7 +58,7 @@ module.exports = function (options, cb) {
   let success = chalk.green(`${path.basename(options.displayDir)} ✓`);
 
   if ( ! options.suppressLogging) console.log(success);
-  
+
   if (cb) return cb(null, { output: success });
 
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "exec plugin for meta for executing synchronous commands to stdout with a standard format",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "exec plugin for meta for executing synchronous commands to stdout with a standard format",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "meta-exec",
+  "name": "@essential-projects/meta-exec",
   "version": "0.0.7",
   "description": "exec plugin for meta for executing synchronous commands to stdout with a standard format",
   "main": "index.js",
@@ -26,6 +26,6 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "debug": "^2.6.0",
-    "meta-loop": "^0.0.5"
+    "@essential-projects/meta-loop": "^0.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@essential-projects/meta-exec",
+  "name": "meta-exec",
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
@@ -29,6 +29,6 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "debug": "^2.6.0",
-    "@essential-projects/meta-loop": "^0.0.7"
+    "meta-loop": "^0.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "exec plugin for meta for executing synchronous commands to stdout with a standard format",
   "main": "index.js",
   "bin": {
@@ -29,6 +29,6 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "debug": "^2.6.0",
-    "@essential-projects/meta-loop": "^0.0.5"
+    "@essential-projects/meta-loop": "^0.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@essential-projects/meta-exec",
+  "publishConfig": {
+    "registry": "https://www.npmjs.com"
+  },
   "version": "0.0.7",
   "description": "exec plugin for meta for executing synchronous commands to stdout with a standard format",
   "main": "index.js",


### PR DESCRIPTION
This adds two options `exit-on-error` and `exit-on-aggregated-error`.

`exit-on-error` directly cancels everything with `process.exit(1)` as soon as an error occurs on a sub command.

`exit-on-aggregated-error` waits until all sub commands have run and then exits with `process.exit(1)`.

I added the options, because without them I didn't find any way to have the exit code on the original `meta` call reflect that errors occured on one of the commands.

This PR also involves PRs for `meta`, `meta-loop` and `loop` itself.

I didn't clean up the commit history and I had to do some version changes during the process to test the changes on my local setup.

I'll gladly clean up everything as soon as you reviewed it, but would like to keep it until then for testing purposes. If you want I can also provide you with a test setup if that might be an issue (wasn't easy for me ;).